### PR TITLE
feat(search): add global keyboard event listener for search focus

### DIFF
--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>页签时空门</title>
+    <title>Pass tabs - 页签时空门</title>
     <meta name="manifest.type" content="browser_action" />
   </head>
 

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -64,4 +64,14 @@ document.addEventListener('DOMContentLoaded', async function () {
     $search.dispatchEvent(new Event('input'))
     $search.focus()
   })
+  //添加全局键盘事件监听器
+  document.addEventListener('keydown', function (event) {
+    // 检查是否按下了 / 键，并且不是在输入框中（避免干扰用户输入）
+    if (event.key === '/' && document.activeElement !== $search) {
+      // 阻止默认行为（避免 / 字符被输入到搜索框）
+      event.preventDefault()
+      // 聚焦到搜索框
+      $search.focus()
+    }
+  })
 })


### PR DESCRIPTION
Add a global keyboard event listener to focus on the search input when the '/' key is pressed, enhancing user experience by providing a quick way to access the search functionality. The event listener ensures it does not interfere with user input in other fields.